### PR TITLE
Inline popup menu v2

### DIFF
--- a/crypto/__init__.py
+++ b/crypto/__init__.py
@@ -12,7 +12,7 @@ ACTIONS = {'encrypt' : _("Encrypt document"),
 class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
     __gtype_name__ = "CryptoPlugin"
     window = GObject.property(type=Gedit.Window)
-    
+
     def do_activate(self):
         try:
             self.initialize()
@@ -20,28 +20,28 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
             import traceback
             print("Error initializing \"Crypto\" plugin")
             print(traceback.print_exc())
-    
+
     def initialize(self):
         from .crypto_ui import Ui
-        
+
         self.data_dir = self.plugin_info.get_data_dir()
-        
+
         ui_path = os.path.join( self.data_dir, "crypto.glade" )
         self.ui = Ui( "gedit-crypto", ui_path )
         self.ui.connect_signals( self )
-        
+
         self.actions = {}
-        
+
         for action_name in ACTIONS:
             action = Gio.SimpleAction(name=action_name)
             self.actions[action_name] = action
             action.connect('activate', getattr(self, action_name))
             self.window.add_action(action)
             self.window.lookup_action(action_name).set_enabled(True)
-        
+
         # Build encrypter when needed to not slow down Gedit startup
         self.enc = None
-    
+
     def do_deactivate(self):
         """
         Remove actions.
@@ -49,43 +49,43 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
         while self.actions:
             name, action = self.actions.popitem()
             self.window.remove_action(name)
-    
+
     def do_update_state(self):
         pass
-    
+
     def encrypt(self, *args):
         if self.enc == None:
             self.enc = Encrypter( self.ui )
-        
+
         cleartext = self.get_current_text()
-        
+
         encrypted = self.enc.encrypt( cleartext )
-        
+
         if not encrypted:
             return
-        
+
         self.show_in_new_document( encrypted )
-    
+
     def decrypt(self, *args):
         if self.enc == None:
             self.enc = Encrypter( self.ui )
-        
+
         encrypted_text = self.get_current_text()
-        
+
         cleartext = self.enc.decrypt( encrypted_text )
-        
+
         if not cleartext:
             return
-        
+
         self.show_in_new_document( cleartext )
-        
+
     def get_current_text(self):
         view = self.window.get_active_view()
         doc = view.get_buffer()
         start = doc.get_start_iter()
         end = doc.get_end_iter()
         return doc.get_text( start, end, False )
-    
+
     def show_in_new_document(self, text):
         self.window.create_tab( True )
         new_view = self.window.get_active_view()
@@ -96,16 +96,16 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
 class GeditCryptoApp(GObject.Object, Gedit.AppActivatable):
     __gtype_name__ = "GeditCryptoApp"
     app = GObject.property(type=Gedit.App)
-    
+
     def do_activate(self):
         self.submenu_ext = self.extend_menu("tools-section-1")
         submenu = Gio.Menu()
         item = Gio.MenuItem.new_submenu(_("Encrypt/decrypt"), submenu)
         self.submenu_ext.append_menu_item(item)
-        
+
         for action in ACTIONS:
             item = Gio.MenuItem.new(ACTIONS[action], "win.%s" % action)
             submenu.append_item(item)
-    
+
     def do_deactivate(self):
         del self.submenu_ext

--- a/crypto/__init__.py
+++ b/crypto/__init__.py
@@ -13,6 +13,12 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
     __gtype_name__ = "CryptoPlugin"
     window = GObject.property(type=Gedit.Window)
 
+    def __init__(self):
+        GObject.Object.__init__(self)
+        self.window = None
+        # Build encrypter when needed to not slow down Gedit startup
+        self.enc = None
+
     def do_activate(self):
         try:
             self.initialize()
@@ -38,9 +44,6 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
             action.connect('activate', getattr(self, action_name))
             self.window.add_action(action)
             self.window.lookup_action(action_name).set_enabled(True)
-
-        # Build encrypter when needed to not slow down Gedit startup
-        self.enc = None
 
     def do_deactivate(self):
         """
@@ -96,6 +99,10 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
 class GeditCryptoApp(GObject.Object, Gedit.AppActivatable):
     __gtype_name__ = "GeditCryptoApp"
     app = GObject.property(type=Gedit.App)
+
+    def __init__(self):
+        GObject.Object.__init__(self)
+        self.app = None
 
     def do_activate(self):
         self.submenu_ext = self.extend_menu("tools-section-1")

--- a/crypto/__init__.py
+++ b/crypto/__init__.py
@@ -4,10 +4,18 @@ from gi.repository import GObject, Gedit, Gio, Gtk, PeasGtk
 import os
 from collections import defaultdict
 
+import locale
+import gettext
+
 from .encrypter import Encrypter
 from .config import load_config
 
 __version__ = '0.5'
+__APP__ = 'gedit-crypto'
+__DIR__ = os.path.join(os.path.dirname(__file__), 'locale')
+
+gettext.install(__APP__, __DIR__)
+locale.bindtextdomain(__APP__, __DIR__)
 
 ACTIONS = {'encrypt' : _("Encrypt document"),
            'decrypt' : _("Decrypt document")}
@@ -62,7 +70,7 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable,
             from .crypto_ui import Ui
             self.data_dir = self.plugin_info.get_data_dir()
             ui_path = os.path.join( self.data_dir, "crypto.glade" )
-            self.ui = Ui( "gedit-crypto", ui_path )
+            self.ui = Ui( __APP__, ui_path )
             self.ui.connect_signals( self )
 
             self.config.bind('show-popup',

--- a/crypto/__init__.py
+++ b/crypto/__init__.py
@@ -3,6 +3,7 @@ gi.require_version('Gedit', '3.0')
 from gi.repository import GObject, Gedit, Gio, Gtk
 import os
 from .encrypter import Encrypter
+from collections import defaultdict
 
 __version__ = '0.5'
 
@@ -19,6 +20,7 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
         # Build encrypter when needed to not slow down Gedit startup
         self.enc = None
         self.handlers_ids = defaultdict(list)
+        self.ui = None
 
     def do_activate(self):
         try:
@@ -29,13 +31,7 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
             print(traceback.print_exc())
 
     def initialize(self):
-        from .crypto_ui import Ui
-
-        self.data_dir = self.plugin_info.get_data_dir()
-
-        ui_path = os.path.join( self.data_dir, "crypto.glade" )
-        self.ui = Ui( "gedit-crypto", ui_path )
-        self.ui.connect_signals( self )
+        self.initialize_ui()
 
         self.actions = {}
 
@@ -50,6 +46,14 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
 
         for view in self.window.get_views():
             self.connect_view(view)
+
+    def initialize_ui(self):
+        if self.ui is None:
+            from .crypto_ui import Ui
+            self.data_dir = self.plugin_info.get_data_dir()
+            ui_path = os.path.join( self.data_dir, "crypto.glade" )
+            self.ui = Ui( "gedit-crypto", ui_path )
+            self.ui.connect_signals( self )
 
     def on_window_tab_added(self, window, tab):
         self.connect_view(tab.get_view())

--- a/crypto/__init__.py
+++ b/crypto/__init__.py
@@ -1,6 +1,6 @@
 import gi
 gi.require_version('Gedit', '3.0')
-from gi.repository import GObject, Gedit, Gio
+from gi.repository import GObject, Gedit, Gio, Gtk
 import os
 from .encrypter import Encrypter
 
@@ -45,6 +45,14 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
             self.window.add_action(action)
             self.window.lookup_action(action_name).set_enabled(True)
 
+        self.window.connect('tab-added', self.on_window_tab_added)
+
+        for view in self.window.get_views():
+            self.connect_view(view)
+
+    def on_window_tab_added(self, window, tab):
+        self.connect_view(tab.get_view())
+
     def do_deactivate(self):
         """
         Remove actions.
@@ -55,6 +63,20 @@ class GeditCrypto(GObject.Object, Gedit.WindowActivatable):
 
     def do_update_state(self):
         pass
+
+    def connect_view(self, view):
+        view.connect('populate-popup', self.on_view_populate_popup)
+
+    def on_view_populate_popup(self, view, menu):
+        separator = Gtk.SeparatorMenuItem()
+        separator.show();
+        menu.append(separator)
+
+        for action in ACTIONS:
+            menu_item = Gtk.MenuItem(ACTIONS[action])
+            menu_item.connect('activate', getattr(self, action))
+            menu_item.show();
+            menu.append(menu_item)
 
     def encrypt(self, *args):
         if self.enc == None:

--- a/crypto/config.py
+++ b/crypto/config.py
@@ -1,0 +1,21 @@
+from gi.repository import Gio
+from os.path import expanduser
+
+# FIXME: detect
+SYSTEM_INSTALL = False
+
+SCHEMA_ID = "org.gnome.gedit.plugins.crypto"
+
+def load_config():
+    if SYSTEM_INSTALL:
+        settings = Gio.Settings.new(SCHEMA_ID)
+    else:
+        # TODO: install and compile automatically
+        schema_path = expanduser("~/.local/share/gedit-crypto/schemas")
+        schema_source = Gio.SettingsSchemaSource.new_from_directory(
+                                    schema_path,
+                                    Gio.SettingsSchemaSource.get_default(),
+                                    False)
+        schema = schema_source.lookup(SCHEMA_ID, False)
+        settings = Gio.Settings.new_full(schema, None, None)
+    return settings

--- a/crypto/crypto.glade
+++ b/crypto/crypto.glade
@@ -231,4 +231,27 @@
       <action-widget response="1">OK_button</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkBox" id="settings_vbox">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkCheckButton" id="show_popup_checkbox">
+        <property name="label" translatable="yes">Show popup menu (needs restart)</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="margin_left">6</property>
+        <property name="margin_right">6</property>
+        <property name="margin_top">6</property>
+        <property name="margin_bottom">6</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
 </interface>

--- a/crypto/crypto.glade
+++ b/crypto/crypto.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.2 -->
-<interface>
+<!-- Generated with glade 3.20.0 -->
+<interface domain="gedit-crypto">
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkMessageDialog" id="error">
     <property name="can_focus">False</property>
@@ -48,6 +48,9 @@
     <action-widgets>
       <action-widget response="0">button</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
   <object class="GtkListStore" id="keys">
     <columns>
@@ -230,6 +233,9 @@
       <action-widget response="0">button1</action-widget>
       <action-widget response="1">OK_button</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
   <object class="GtkBox" id="settings_vbox">
     <property name="visible">True</property>

--- a/crypto/crypto_ui.py
+++ b/crypto/crypto_ui.py
@@ -31,7 +31,7 @@ class Ui(object):
         self._builder = Gtk.Builder()
         self._builder.set_translation_domain( APP )
         self._builder.add_from_file( filename )
-    
+
     def __getattr__(self, attr_name):
         try:
             return object.__getattribute__( self, attr_name )
@@ -42,6 +42,6 @@ class Ui(object):
                 return obj
             else:
                 raise AttributeError("no object named \"%s\" in the GUI." % attr_name)
-    
+
     def connect_signals(self, target):
         self._builder.connect_signals( target )

--- a/crypto/encrypter.py
+++ b/crypto/encrypter.py
@@ -7,39 +7,39 @@ class Encrypter(object):
         self.ui = ui
         self.bus = dbus.SessionBus()
         self.init_dbus()
-            
+
     def init_dbus(self):
         keys_proxy = self.bus.get_object('org.gnome.seahorse', '/org/gnome/seahorse/keys')
         key_service = dbus.Interface(keys_proxy, 'org.gnome.seahorse.KeyService')
-        
+
         types = key_service.GetKeyTypes()
-        
+
         path = key_service.GetKeyset(types[0])
-        
+
         proxy_obj = self.bus.get_object('org.gnome.seahorse', path)
         self.keyset = dbus.Interface(proxy_obj, "org.gnome.seahorse.Keys")
-    
+
     def select_key(self):
         self.populate_keys_list()
-        
+
         resp = self.ui.main.run()
         self.ui.main.hide()
         if resp != 1:
             return
         return list( self.shown[self.ui.key_selection.get_selected()[1]] )
-    
+
     def populate_keys_list(self):
         keys = self.keyset.ListKeys()
-        
+
         self.shown = Gtk.TreeModelFilter( child_model=self.ui.keys )
         self.shown.set_visible_func( self.show_key, None )
-                
+
         self.ui.keys_view.set_model( self.shown )
         self.ui.search.connect( "changed", (lambda x : self.shown.refilter()) )
         self.ui.key_selection.connect( "changed", self.activate_OK_button )
-        
+
         self.ui.keys.clear()
-        
+
         fields_names = [ "display-name", "display-id", "fingerprint" ]
         # Fields are well described in
         # https://lug.asprion.org/wiki/1/Seahorse_DBUS_Interface
@@ -47,9 +47,9 @@ class Encrypter(object):
         # those).
         # Never found: "expires","enc-type"
         # "display-id" always the same as "raw-id"
-        
+
         duplicates = set()
-        
+
         for key in keys:
             if key.count(':') == 2:
                 # The correct format is e.g. "openpgp:0123456789ABCDE0";
@@ -70,26 +70,26 @@ class Encrypter(object):
                                      key])
         warnings.warn("Discarded the following keys, apparently duplicates:\n"
                       "%s" % duplicates)
-    
+
     def show_key(self, store, the_iter, data):
         search = self.ui.search.get_text()
         if not search:
             # No search currently active
             return True
-        
+
         return search.lower() in self.ui.keys[the_iter][3]
-    
+
     def activate_OK_button(self, selection):
         self.ui.OK_button.set_sensitive( bool( selection.get_selected()[1] ) )
-    
+
     def encrypt(self, cleartext):
         self.chosen = self.select_key()
         if not self.chosen:
             return
-        
+
         cr_proxy = self.bus.get_object('org.gnome.seahorse', '/org/gnome/seahorse/crypto')
         cr_service = dbus.Interface(cr_proxy, 'org.gnome.seahorse.CryptoService')
-        
+
         try:
             key = self.chosen[-1]
             encrypted = cr_service.EncryptText([key], "", 0, cleartext)
@@ -100,11 +100,11 @@ class Encrypter(object):
             self.ui.error.format_secondary_text( str(msg) )
             self.ui.error.run()
             self.ui.error.hide()
-    
+
     def decrypt(self, encrypted_text):
         cr_proxy = self.bus.get_object('org.gnome.seahorse', '/org/gnome/seahorse/crypto')
         cr_service = dbus.Interface(cr_proxy, 'org.gnome.seahorse.CryptoService')
-        
+
         try:
             # Notice "signer" is not returned:
             cleartext, signer = cr_service.DecryptText( "openpgp", 0, encrypted_text )

--- a/crypto/encrypter.py
+++ b/crypto/encrypter.py
@@ -95,8 +95,8 @@ class Encrypter(object):
             encrypted = cr_service.EncryptText([key], "", 0, cleartext)
             return encrypted
         except dbus.exceptions.DBusException as msg:
-            self.ui.error.set_title( "Encryption error" )
-            self.ui.error.set_markup( "The encryption process failed due to the following error:" )
+            self.ui.error.set_title( _("Encryption error") )
+            self.ui.error.set_markup( _("The encryption process failed due to the following error:") )
             self.ui.error.format_secondary_text( str(msg) )
             self.ui.error.run()
             self.ui.error.hide()
@@ -110,8 +110,8 @@ class Encrypter(object):
             cleartext, signer = cr_service.DecryptText( "openpgp", 0, encrypted_text )
             return cleartext
         except dbus.exceptions.DBusException as msg:
-            self.ui.error.set_title( "Decryption error" )
-            self.ui.error.set_markup( "The decryption process failed due to the following error:" )
+            self.ui.error.set_title( _("Decryption error") )
+            self.ui.error.set_markup( _("The decryption process failed due to the following error:") )
             self.ui.error.format_secondary_text( str(msg) )
             self.ui.error.run()
             self.ui.error.hide()

--- a/crypto/encrypter.py
+++ b/crypto/encrypter.py
@@ -112,7 +112,6 @@ class Encrypter(object):
         except dbus.exceptions.DBusException as msg:
             self.ui.error.set_title( "Decryption error" )
             self.ui.error.set_markup( "The decryption process failed due to the following error:" )
-            self.ui.error.format_secondary_text( msg )
+            self.ui.error.format_secondary_text( str(msg) )
             self.ui.error.run()
             self.ui.error.hide()
-

--- a/crypto/po/fr.po
+++ b/crypto/po/fr.po
@@ -1,0 +1,71 @@
+# French translations for gedit-crypto package
+# Traductions françaises du paquet gedit-crypto.
+# Copyright (C) 2017 Pietro Battiston
+# This file is distributed under the same license as gedit-crypto.
+# Emmanuel Bossière, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gedit-crypto 0.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-05 20:38+0200\n"
+"PO-Revision-Date: 2017-04-17 19:31+0200\n"
+"Last-Translator: Emmanuel Bossière\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: encrypter.py:98
+msgid "Encryption error"
+msgstr "Erreur de chiffrement"
+
+#: encrypter.py:99
+msgid "The encryption process failed due to the following error:"
+msgstr "Le chiffrement a échoué en raison de l'erreur suivante:"
+
+#: encrypter.py:113
+msgid "Decryption error"
+msgstr "Erreur de déchiffrement"
+
+#: encrypter.py:114
+msgid "The decryption process failed due to the following error:"
+msgstr "Le déchiffrement a échoué en raison de l'erreur suivante:"
+
+#: __init__.py:20
+msgid "Encrypt document"
+msgstr "Chiffrer le document"
+
+#: __init__.py:21
+msgid "Decrypt document"
+msgstr "Déchiffrer le document"
+
+#: __init__.py:168
+msgid "Encrypt/decrypt"
+msgstr "Chiffrer/déchiffrer"
+
+#: crypto.glade:74
+msgid "Key selection"
+msgstr "Sélection de la clé"
+
+#: crypto.glade:138
+msgid "Search:"
+msgstr "Recherche:"
+
+#: crypto.glade:183
+msgid "Key"
+msgstr "Clé"
+
+#: crypto.glade:194
+msgid "Id"
+msgstr "Identifiant"
+
+#: crypto.glade:205
+msgid "Fingerprint"
+msgstr "Empreinte"
+
+#: crypto.glade:246
+msgid "Show popup menu (needs restart)"
+msgstr "Afficher l'option dans le menu contextuel (redémarrage nécessaire)"

--- a/crypto/po/gedit-crypto.pot
+++ b/crypto/po/gedit-crypto.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2017 Pietro Battiston
+# This file is distributed under the same license as the gedit-crypto package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: gedit-crypto 0.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-05 20:38+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: encrypter.py:98
+msgid "Encryption error"
+msgstr ""
+
+#: encrypter.py:99
+msgid "The encryption process failed due to the following error:"
+msgstr ""
+
+#: encrypter.py:113
+msgid "Decryption error"
+msgstr ""
+
+#: encrypter.py:114
+msgid "The decryption process failed due to the following error:"
+msgstr ""
+
+#: __init__.py:20
+msgid "Encrypt document"
+msgstr ""
+
+#: __init__.py:21
+msgid "Decrypt document"
+msgstr ""
+
+#: __init__.py:168
+msgid "Encrypt/decrypt"
+msgstr ""
+
+#: crypto.glade:74
+msgid "Key selection"
+msgstr ""
+
+#: crypto.glade:138
+msgid "Search:"
+msgstr ""
+
+#: crypto.glade:183
+msgid "Key"
+msgstr ""
+
+#: crypto.glade:194
+msgid "Id"
+msgstr ""
+
+#: crypto.glade:205
+msgid "Fingerprint"
+msgstr ""
+
+#: crypto.glade:246
+msgid "Show popup menu (needs restart)"
+msgstr ""

--- a/crypto/schemas/org.gnome.gedit.plugins.crypto.gschema.xml
+++ b/crypto/schemas/org.gnome.gedit.plugins.crypto.gschema.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.gedit.plugins.crypto"
+          path="/org/gnome/gedit/plugins/crypto/">
+    <key type="b" name="show-popup">
+      <default>true</default>
+      <summary>Show popup menu</summary>
+      <description>Show popup menu with inline encrypt/decrypt option.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
This is a "reinterpretation" of #1. Sorry for the long wait.

There are some things I still didn't have time to do:
- I don't want to include .mo files, but I do want to include a script which automatically generates them
- I don't want to make root privilegies a requirement, but I do want the plugin to use a globally available gsettings schema if available, and to automatically compile it otherwise
- it shouldn't be very difficult to _not_ require restarting for the "inline menu" setting to apply

A more serious difference from #1 is that I don't like the "encrypt/decrypt in the same tab" feature, because it makes it easy to either replace the encrypted version with the plain one, or vice-versa, by mistake (e.g. by just clicking Ctrl+S), both things a user might see as harmful. Ideally, the plugin should automatically re-encrypt while saving an encrypted file which has been (decrypted and) edited, and possibly provide a "Encrypt as" feature. And I think Gedit provides all the required hooks... but I'm not sure.

Any comment is welcome.